### PR TITLE
# 백앤드 search 404에러 수정

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,25 +76,6 @@ app.get("/companies", async (req, res) => {
 // api: /companies/comparison GET
 // app.get("/companies/comparison", async (req, res) => {}
 
-//특정 기업 상세 조회
-app.get("/companies/:id", async (req, res) => {
-  const { id } = req.params;
-  const numId = parseInt(id, 10);
-  try {
-    const startup = await prisma.startup.findUnique({
-      where: { id: numId },
-    });
-    const serializedStartups = JSON.stringify(startup, replacer);
-    res.send(serializedStartups);
-  } catch (error) {
-    res.status(404).send({ message: error.message });
-  }
-});
-
-// 내 기업의 순위와 근접한 순위의 기업 정보 확인
-// api: /companies/{companyId}/rank GET
-// app.get("/companies/id/rank", async (req, res) => {}
-
 // 검색 기능
 app.get("/companies/search", async (req, res) => {
   const { searchKeyword, offset = 0, limit = 10 } = req.query;
@@ -113,6 +94,25 @@ app.get("/companies/search", async (req, res) => {
     res.status(404).send({ message: error.message });
   }
 });
+
+//특정 기업 상세 조회
+app.get("/companies/:id", async (req, res) => {
+  const { id } = req.params;
+  const numId = parseInt(id, 10);
+  try {
+    const startup = await prisma.startup.findUnique({
+      where: { id: numId },
+    });
+    const serializedStartups = JSON.stringify(startup, replacer);
+    res.send(serializedStartups);
+  } catch (error) {
+    res.status(404).send({ message: error.message });
+  }
+});
+
+// 내 기업의 순위와 근접한 순위의 기업 정보 확인
+// api: /companies/{companyId}/rank GET
+// app.get("/companies/id/rank", async (req, res) => {}
 
 // 기업 선택 횟수 조회
 app.get("/selections", async (req, res) => {


### PR DESCRIPTION
# 백앤드 search 404에러 수정
- search API 테스트시 발생한 404 에러는  소스코드 상에서 /companie/:id  보다 밑에 있어서 발생했다. 코드상에서 순서를 바꿔줬다.

   자세한 설명: Express는 요청 경로를 위에서 아래로 평가하며,
                         특정 문자열 경로보다 동적 경로가 우선 매칭될 수 있습니다.
                         동적 경로는 어떤 값이든 매칭되므로, 고정 경로를 동적 경로보다
                         먼저 선언해야 정확히 매칭됩니다.

                          라우트 선언 순서가 중요하며, 정적 라우트를 동적 라우트보다 앞에 배치하여
                         충돌을 방지해야 합니다.