### PR TITLE
선택한 기업과 비교기업 5개의  카운트 업데이트

### DIFF
--- a/app.js
+++ b/app.js
@@ -138,6 +138,37 @@ app.get(
   })
 );
 
+// 동적 URL과 쿼리스트링 같이 사용한 경우
+app.get(
+  "/api/startups/test/:startupsId/:comparisonIds",
+  asyncHandler(async (req, res) => {
+    const id = req.params.startupsId;
+    console.log(id);
+    const idNum = parseInt(id, 10);
+    const startup = await prisma.startup.findUniqueOrThrow({
+      where: { id: idNum },
+    });
+
+    const { order = "asc" } = req.query;
+    const orderBy = orderByStartup(order);
+
+    const ids = req.params.comparisonIds;
+    const arr = JSON.parse(ids);
+    console.log(arr, orderBy);
+
+    const startups = await prisma.startup.findMany({
+      orderBy,
+      where: {
+        id: {
+          in: arr,
+        },
+      },
+    });
+    startups.concat(startup);
+    res.send(JSON.stringify(startups, replacer));
+  })
+);
+
 /**
  * id와 같은 동적 url은 search 기능 하단에 배치하는 것이 좋다.
  */
@@ -196,7 +227,61 @@ app.get(
 
 // 나의 기업 선택하기(POST: /api/selections/{startupId}/myStartup)
 
-// 비교 기업 선택하기(POST: /api/selections/{startupId}/compareStartup)
+// 비교 기업 선택하기(PATCH: /api/selections/{startupId}/compareStartup)
+// PATCH http://localhost:8000/api/startups/selections?startupId=5&compareIds=48,17,15
+app.patch("/api/startups/selections", async (req, res) => {
+  const { startupId, compareIds } = req.query;
+
+  if (!startupId) {
+    return res.status(400).json({ error: "startupId is required" });
+  }
+
+  const startupIdNum = parseInt(startupId, 10);
+  if (isNaN(startupIdNum)) {
+    return res.status(400).json({ error: "Invalid startupId format" });
+  }
+
+  let compareIdsArray = [];
+  if (compareIds) {
+    compareIdsArray = compareIds
+      .split(",")
+      .map((id) => parseInt(id, 10))
+      .filter((id) => !isNaN(id));
+  }
+
+  try {
+    // 선택한 기업의 count 증가
+    const updatedSelectStartup = await prisma.startup.update({
+      where: { id: startupIdNum },
+      data: {
+        count: {
+          increment: 1,
+        },
+      },
+    });
+
+    // 비교 대상 기업들의 compareCount 증가
+    const updatedCompareStartups = await prisma.startup.updateMany({
+      where: { id: { in: compareIdsArray } },
+      data: {
+        compareCount: {
+          increment: 1,
+        },
+      },
+    });
+
+    // 응답 데이터 형식화
+    const responseData = {
+      selectedStartup: updatedSelectStartup,
+      updatedCompareStartupsCount: updatedCompareStartups.count,
+    };
+
+    // BigInt 값을 문자열로 변환하여 JSON 응답 생성
+    res.send(JSON.stringify(responseData, replacer));
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
 
 // 전체 투자 현황 조회
 app.get(

--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ const prisma = new PrismaClient();
 
 const app = express();
 app.use(express.json());
-app.use(cors({ origin: '*', credentials: true}));
+app.use(cors({ origin: "*", credentials: true }));
 
 // BigInt 값을 문자열로 변환하여 JSON 응답 생성
 const replacer = (key, value) => {
@@ -136,37 +136,6 @@ app.get(
   })
 );
 
-// 동적 URL과 쿼리스트링 같이 사용한 경우
-app.get(
-  "/api/startups/test/:startupsId/:comparisonIds",
-  asyncHandler(async (req, res) => {
-    const id = req.params.startupsId;
-    console.log(id);
-    const idNum = parseInt(id, 10);
-    const startup = await prisma.startup.findUniqueOrThrow({
-      where: { id: idNum },
-    });
-
-    const { order = "asc" } = req.query;
-    const orderBy = orderByStartup(order);
-
-    const ids = req.params.comparisonIds;
-    const arr = JSON.parse(ids);
-    console.log(arr, orderBy);
-
-    const startups = await prisma.startup.findMany({
-      orderBy,
-      where: {
-        id: {
-          in: arr,
-        },
-      },
-    });
-    startups.concat(startup);
-    res.send(JSON.stringify(startups, replacer));
-  })
-);
-
 /**
  * id와 같은 동적 url은 search 기능 하단에 배치하는 것이 좋다.
  */
@@ -225,8 +194,7 @@ app.get(
 
 // 나의 기업 선택하기(POST: /api/selections/{startupId}/myStartup)
 
-// 비교 기업 선택하기(PATCH: /api/selections/{startupId}/compareStartup)
-// PATCH http://localhost:8000/api/startups/selections?startupId=5&compareIds=48,17,15
+// 비교 기업 선택하기(PATCH: /api/selections/?startupId=2&compareIds=4,8,17,25,33)
 app.patch("/api/startups/selections", async (req, res) => {
   const { startupId, compareIds } = req.query;
 
@@ -248,33 +216,49 @@ app.patch("/api/startups/selections", async (req, res) => {
   }
 
   try {
-    // 선택한 기업의 count 증가
-    const updatedSelectStartup = await prisma.startup.update({
-      where: { id: startupIdNum },
-      data: {
-        count: {
-          increment: 1,
-        },
-      },
-    });
+    // 트랜잭션 시작
+    const [updatedSelectStartup, updateCompareCountResult] =
+      await prisma.$transaction([
+        // 선택된 스타트업의 count 증가 후 현재 count 가져오기
+        prisma.startup.update({
+          where: { id: startupIdNum },
+          data: {
+            count: {
+              increment: 1,
+            },
+          },
+          select: { count: true }, // count 값만 가져오기
+        }),
 
-    // 비교 대상 기업들의 compareCount 증가
-    const updatedCompareStartups = await prisma.startup.updateMany({
+        // 비교 대상 기업들의 compareCount 증가
+        prisma.startup.updateMany({
+          where: { id: { in: compareIdsArray } },
+          data: {
+            compareCount: {
+              increment: 1,
+            },
+          },
+        }),
+      ]);
+
+    // 업데이트 후 비교 대상 기업들의 각기 compareCount 값 가져오기
+    const updatedCompareStartups = await prisma.startup.findMany({
       where: { id: { in: compareIdsArray } },
-      data: {
-        compareCount: {
-          increment: 1,
-        },
-      },
+      select: { id: true, compareCount: true }, // id와 compareCount만 가져오기
     });
 
     // 응답 데이터 형식화
     const responseData = {
-      selectedStartup: updatedSelectStartup,
-      updatedCompareStartupsCount: updatedCompareStartups.count,
+      selectedStartupCount: updatedSelectStartup.count,
+      compareStartupsCounts: updatedCompareStartups.map(
+        ({ id, compareCount }) => ({
+          id,
+          compareCount,
+        })
+      ),
     };
 
-    // BigInt 값을 문자열로 변환하여 JSON 응답 생성
+    // BigInt 값들을 처리한 후 JSON 응답
     res.send(JSON.stringify(responseData, replacer));
   } catch (error) {
     res.status(500).json({ message: error.message });

--- a/test.http
+++ b/test.http
@@ -16,3 +16,9 @@ GEt http://localhost:8000/api/startups/search?searchKeyword=코
 GET http://localhost:8000/api/startups/comparison?startupId=5&compareIds=48,17,15&order=employeesAsc
 
 //asc: 오름차순, desc:내림차순, 사용되는 order는 actualInvest(누적 투자금액),revenue(매출액),employees(고용 인원)
+
+###
+GET http://localhost:8000/api/startups/test/5/[2,4,8,17,25,33]?&order=id
+
+###
+PATCH http://localhost:8000/api/startups/selections?startupId=2&compareIds=4,8,17,25,33


### PR DESCRIPTION
### 선택한 기업과 비교기업 5개의  카운트 업데이트

- 선택한 기업 count 와 비교기업 5개의  compareCount를 1만큼 증가시킨다.

- 코드 내용
  프론트앤드에서 보내온 선택기업의 ID와 비교기업 최대5개의 ID를 이용하여,
  해당 선택기업의 count와 비교 기업들의 compareCount를 1만큼 증가시킨다.
  이때 update와 updateMany 작업을 트랜잭션 안에서 실행한다.
  두 작업 중 하나라도 실패하면 전체 트랜잭션이 롤백되어진다.

  이후 새롭게 update 된 카운트 값들로, 프론트앤드에 응답 데이터를 보낸다.

- 테스트 방법
  PATCH http://localhost:8000/api/startups/selections?startupId=5&compareIds=48,17,15